### PR TITLE
Improve SSL handling fallback for GetResponseBody

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,79 @@
-Este projeto é de estudos de kafka e aplicações de microserviços, rodando com conceito de docker
+Este projeto é de estudos de Kafka e aplicações de microserviços, rodando com conceito de Docker.
 
- s
+## Melhoria sugerida para `GetResponseBody`
+
+A função original podia ficar presa em um loop infinito quando a conexão falhava
+indefinidamente e não distinguia o tratamento entre URLs e arquivos locais. O
+exemplo abaixo ilustra uma versão mais robusta que adiciona limite de tentativas,
+intervalo incremental entre as execuções e uso explícito de codificação ao
+normalizar o HTML com o BeautifulSoup.
+
+```python
+import time
+from pathlib import Path
+import ssl
+from urllib import error, request
+
+from bs4 import BeautifulSoup
+
+
+def get_response_body(
+    dados: str,
+    timeout: int = 30,
+    max_retries: int = 3,
+    cafile: str | None = None,
+    allow_insecure_fallback: bool = False,
+) -> str:
+    path = Path(dados)
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+
+    last_error: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            if cafile:
+                context = ssl.create_default_context(cafile=cafile)
+            else:
+                try:
+                    import certifi
+                except ModuleNotFoundError:
+                    context = None
+                else:
+                    context = ssl.create_default_context(cafile=certifi.where())
+            with request.urlopen(dados, timeout=timeout, context=context) as response:
+                encoding = response.headers.get_content_charset() or "utf-8"
+                html = response.read().decode(encoding, errors="replace")
+
+            page_items = BeautifulSoup(html, "html.parser")
+            return str(page_items)
+        except (error.URLError, error.HTTPError, ValueError) as exc:
+            last_error = exc
+            if attempt < max_retries:
+                time.sleep(attempt)
+            reason = getattr(exc, "reason", None)
+            reason_text = str(reason or exc)
+            is_cert_failure = isinstance(reason, ssl.SSLCertVerificationError) or (
+                isinstance(reason, ssl.SSLError)
+                and "CERTIFICATE_VERIFY_FAILED" in reason_text.upper()
+            )
+            if allow_insecure_fallback and is_cert_failure:
+                context = ssl._create_unverified_context()
+                context.check_hostname = False
+                with request.urlopen(dados, timeout=timeout, context=context) as response:
+                    encoding = response.headers.get_content_charset() or "utf-8"
+                    html = response.read().decode(encoding, errors="replace")
+
+                return str(BeautifulSoup(html, "html.parser"))
+
+    raise RuntimeError(f"Não foi possível obter o conteúdo de {dados!r}") from last_error
+```
+
+Outras melhorias recomendadas:
+
+- Registrar logs para facilitar a observação de falhas de rede.
+- Expor parâmetros como *parser*, tempo de *backoff* e contexto SSL para ajuste fino.
+- Instalar o pacote [`certifi`](https://pypi.org/project/certifi/) para obter uma
+  cadeia de certificados confiáveis multiplataforma quando o sistema operacional
+  não disponibiliza *roots* atualizadas.
+- Propagar exceções específicas quando apropriado, em vez de simplesmente
+  silenciá-las.

--- a/versoes_anteriores/get_response_body.py
+++ b/versoes_anteriores/get_response_body.py
@@ -1,0 +1,130 @@
+"""Ferramentas auxiliares para leitura de HTML em aplicações de ETL."""
+
+from __future__ import annotations
+
+import logging
+import ssl
+import time
+from pathlib import Path
+from typing import Union
+from urllib import error, request
+
+from bs4 import BeautifulSoup
+
+try:  # pragma: no cover - dependência opcional
+    import certifi
+except ModuleNotFoundError:  # pragma: no cover - dependência opcional
+    certifi = None
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_response_body(
+    dados: Union[str, Path],
+    *,
+    timeout: int = 30,
+    max_retries: int = 3,
+    backoff_factor: float = 1.0,
+    parser: str = "html.parser",
+    ssl_context: ssl.SSLContext | None = None,
+    cafile: Union[str, Path, None] = None,
+    allow_insecure_fallback: bool = False,
+) -> str:
+    """Retorna o HTML normalizado para a URL ou caminho informado.
+
+    A função trata tanto URLs quanto caminhos locais. Quando ``dados`` é um
+    caminho, o arquivo é lido diretamente do disco. Para URLs, uma política de
+    tentativas com ``max_retries`` é aplicada antes de propagar uma exceção.
+
+    Parameters
+    ----------
+    dados:
+        URL ou caminho do conteúdo.
+    timeout:
+        Tempo máximo (em segundos) para aguardar a resposta de cada tentativa.
+    max_retries:
+        Número máximo de tentativas antes de falhar.
+    backoff_factor:
+        Multiplicador aplicado ao tempo de espera entre tentativas.
+    parser:
+        Parser utilizado pelo BeautifulSoup.
+
+    Returns
+    -------
+    str
+        Representação HTML normalizada pelo BeautifulSoup.
+
+    Raises
+    ------
+    RuntimeError
+        Quando não é possível obter o conteúdo após as tentativas realizadas.
+    """
+
+    path = Path(dados)
+    if path.exists():
+        LOGGER.debug("Lendo conteúdo local de %s", path)
+        return path.read_text(encoding="utf-8")
+
+    last_error: Exception | None = None
+    insecure_attempted = False
+
+    def build_context(disable_verification: bool = False) -> ssl.SSLContext | None:
+        if ssl_context is not None:
+            return ssl_context
+        if disable_verification:
+            LOGGER.warning(
+                "SSL desabilitado para %s por solicitação explícita.",
+                dados,
+            )
+            insecure_context = ssl._create_unverified_context()
+            insecure_context.check_hostname = False
+            return insecure_context
+        if cafile is not None:
+            return ssl.create_default_context(cafile=str(cafile))
+        if certifi is not None:
+            return ssl.create_default_context(cafile=certifi.where())
+        return None
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            LOGGER.debug("Tentativa %s de leitura remota de %s", attempt, dados)
+            context = build_context(disable_verification=insecure_attempted)
+            with request.urlopen(str(dados), timeout=timeout, context=context) as response:
+                encoding = response.headers.get_content_charset() or "utf-8"
+                html = response.read().decode(encoding, errors="replace")
+
+            page_items = BeautifulSoup(html, parser)
+            return str(page_items)
+        except (error.URLError, error.HTTPError, ValueError) as exc:
+            last_error = exc
+            LOGGER.warning(
+                "Falha ao obter HTML de %s na tentativa %s/%s: %s",
+                dados,
+                attempt,
+                max_retries,
+                exc,
+            )
+            reason = getattr(exc, "reason", None)
+            reason_text = str(reason or exc)
+            is_cert_failure = isinstance(reason, ssl.SSLCertVerificationError) or (
+                isinstance(reason, ssl.SSLError)
+                and "CERTIFICATE_VERIFY_FAILED" in reason_text.upper()
+            )
+            if allow_insecure_fallback and not insecure_attempted and is_cert_failure:
+                LOGGER.warning(
+                    "Nova tentativa para %s com verificação SSL desabilitada; considere "
+                    "configurar um arquivo de certificados de confiança (cafile).",
+                    dados,
+                )
+                insecure_attempted = True
+                continue
+            if attempt < max_retries:
+                sleep_for = backoff_factor * attempt
+                LOGGER.debug("Aguardando %s segundo(s) antes da nova tentativa", sleep_for)
+                time.sleep(sleep_for)
+
+    raise RuntimeError(f"Não foi possível obter o conteúdo de {dados!r}") from last_error
+
+
+__all__ = ["get_response_body"]


### PR DESCRIPTION
## Summary
- load the certifi CA bundle when available to improve certificate compatibility
- harden certificate error detection and ensure hostname checks are disabled in insecure mode
- document the automatic certifi usage and updated fallback behaviour in the README helper snippet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e56bbc9b88833298280da89719bcba